### PR TITLE
fix field name for LambdaInfo

### DIFF
--- a/src/ASTInterpreter.jl
+++ b/src/ASTInterpreter.jl
@@ -102,7 +102,7 @@ function enter(meth, tree::Expr, env, parent = Nullable{Interpreter}(); loctree 
     interp
 end
 function enter(meth::Method, env::Environment, parent = Nullable{Interpreter}(); kwargs...)
-    ast = Base.uncompressed_ast(meth.func.code)
+    ast = Base.uncompressed_ast(meth.func.def)
     tree = ast.args[3]
     enter(meth, tree, env, parent; kwargs...)
 end


### PR DESCRIPTION
I had to make this change to load this module in `v0.5`

```
Julia Version 0.5.0-dev+2845
Commit 4ce06c2 (2016-02-23 09:49 UTC)
```
