### PR TITLE
Show location info from atsign-enter

### DIFF
--- a/src/ASTInterpreter.jl
+++ b/src/ASTInterpreter.jl
@@ -779,7 +779,7 @@ function expression_mismatch(loweredast, parsedexpr, thecalls, theassignments, f
         elseif isexpr(node, :(=))
             if isempty(theassignments)
                 println("Failed to match $node")
-                return    
+                return
             end
             println("Matching assignment $node with $(shift!(theassignments))")
         end
@@ -828,7 +828,7 @@ function process_loctree(res, contents, linfo, complete = true)
             end
         end
     catch err
-        if isa(err, MatchingError) 
+        if isa(err, MatchingError)
             expression_mismatch(loweredast, parsedexpr, collectcalls(SourceFile(contents), parsedexpr, parsedloc, complete)...)
         elseif fancy_mode
             rethrow(err)
@@ -922,7 +922,7 @@ function prepare_locals(linfo, argvals = ())
     Environment(locals, gensyms, sparams)
 end
 
-function enter_call_expr(interp, expr)
+function enter_call_expr(interp, expr, showlocation::Bool=false)
     f = to_function(expr.args[1])
     allargs = expr.args
     if is(f,Base._apply)
@@ -938,6 +938,9 @@ function enter_call_expr(interp, expr)
             println(f)
             println(argtypes)
             rethrow(err)
+        end
+        if showlocation
+            println(method.func.file, ':', method.func.line)
         end
         argtypes = Tuple{_Typeof(f), argtypes.parameters...}
         args = allargs
@@ -1439,7 +1442,7 @@ macro enter(arg)
     quote
         theargs = $(esc(Expr(:tuple,arg.args...)))
         ASTInterpreter.RunDebugREPL(
-            ASTInterpreter.enter_call_expr(nothing,Expr(:call,theargs...)))
+            ASTInterpreter.enter_call_expr(nothing,Expr(:call,theargs...),true))
     end
 end
 


### PR DESCRIPTION
This causes `@enter` to show file & line number information. Example:

``` jl
julia> @enter sync(A, C)
/home/tim/.julia/v0.5/ArrayIterationPlayground/src/core.jl:87
86  function sync(A::AllElements, B::AllElements)
87      check_sameinds(A, B)
88      _sync(storageorder(A), storageorder(B), A, B)
89  end

About to run: ArrayIterationPlayground.check_sameinds
1|debug > 
```
