### PR TITLE
Added simple ? help at debug prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 The AST Interpreter component of Gallium (i.e. does not include any breakpoint,
   stuff, etc.). This is a development prototype and comes with it's own debug
   prompt for that purpose.
-  
+
 Usage:
 ```
 using ASTInterpreter
@@ -19,7 +19,7 @@ interp = enter(foo, Environment(Dict(:n => 20),Dict{Symbol,Any}()))
 ASTInterpreter.RunDebugREPL(interp)
 ```
 Basic Commands:
-- `n` steps to the line
+- `n` steps to the next line
 - `s` steps into the next call
 - `finish` runs to the end of the function
 - `bt` shows a simple backtrace
@@ -32,6 +32,7 @@ Advanced commands:
 - `ns` steps to the next statement
 - `se` does one expression step
 - `si` does the same but steps into a call if a call is the next expression
+- `sg` steps into a generated function
 - `shadow` shows the internal representation of the expression tree (for debugger debugging only)
 - `loc` shows the column data for the current top frame, in the same format
   as JuliaParsers's testshell.

--- a/src/ASTInterpreter.jl
+++ b/src/ASTInterpreter.jl
@@ -1350,6 +1350,32 @@ function done_stepping!(state, interp; to_next_call = false)
     interp
 end
 
+function execute_command(state, interp::Interpreter, ::Val{:?}, cmd)
+    display(
+            Base.@md_str """
+    Basic Commands:\\
+    - `n` steps to the next line\\
+    - `s` steps into the next call\\
+    - `finish` runs to the end of the function\\
+    - `bt` shows a simple backtrace\\
+    - ``` `stuff ``` runs `stuff` in the current frame's context\\
+    - `fr v` will show all variables in the current frame\\
+    - `f n` where `n` is an integer, will go to the `n`-th frame.
+
+    Advanced commands:\\
+    - `nc` steps to the next call\\
+    - `ns` steps to the next statement\\
+    - `se` does one expression step\\
+    - `si` does the same but steps into a call if a call is the next expression\\
+    - `sg` steps into a generated function\\
+    - `shadow` shows the internal representation of the expression tree\\
+       (for debugger debugging only)\\
+    - `loc` shows the column data for the current top frame,\\
+        in the same format as JuliaParsers's testshell.\\
+    """)
+    return false
+end
+
 function execute_command(state, interp::Interpreter, ::Val{:finish}, cmd)
     finish!(state.interp)
     done_stepping!(state, state.interp; to_next_call = true)


### PR DESCRIPTION
Fixes https://github.com/Keno/Gallium.jl/issues/66.

Now:
![help](https://cloud.githubusercontent.com/assets/4098145/16982417/eae1a1dc-4e6f-11e6-8aae-9c77e857066c.png)

I decided against using standard markdown list as that takes up much more space.
I also added the command `sg` to this list and the readme.

This is a super non-fancy implementation, but maybe good enough for now? But feel free to just close if too non-fancy.
