### PR TITLE
Check isdefined(lambdainfo, :slotnames) before accessing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ os:
   - linux
   - osx
 julia:
+  - 0.5
   - nightly
 notifications:
   email: false


### PR DESCRIPTION
This fixes the following error:
```jl
julia> @noinline foo(r) = r.start
foo (generic function with 1 method)

julia> @noinline function bar(start, stop)
           r = start:stop
           x = foo(r)
           x*x+x
       end
bar (generic function with 1 method)

julia> using Gallium
INFO: Recompiling stale cache file /home/tim/.julia/lib/v0.5/ASTInterpreter.ji for module ASTInterpreter.
INFO: Recompiling stale cache file /home/tim/.julia/lib/v0.5/Gallium.ji for module Gallium.

julia> breakpoint(foo)
Locations (+: active, -: inactive, *: source):
 * Any matching method added to #foo
 * Any matching specialization of foo(r) at REPL[1]:1


julia> bar(1,5)
In REPL[1]:1
1 @noinline foo(r) = r.start

About to run: Core.getfield
1|debug > up
In REPL[2]:2
2     r = start:stop
3     x = foo(r)
4     x*x+x
5 end

2|julia > r
ERROR: UndefRefError: access to undefined reference
 in eval_in_interp(::Gallium.JuliaStackFrame, ::Symbol, ::Symbol, ::String) at /home/tim/.julia/v0.5/ASTInterpreter/src/ASTInterpreter.jl:1266
 in eval_code(::ASTInterpreter.InterpreterState, ::String) at /home/tim/.julia/v0.5/ASTInterpreter/src/ASTInterpreter.jl:1551
 in (::ASTInterpreter.##72#78{ASTInterpreter.InterpreterState,Base.LineEdit.Prompt})(::Base.LineEdit.MIState, ::Base.AbstractIOBuffer{Array{UInt8,1}}, ::Bool) at /home/tim/.julia/v0.5/ASTInterpreter/src/ASTInterpreter.jl:1676
 in run_interface(::Base.Terminals.TTYTerminal, ::Base.LineEdit.ModalInterface) at ./LineEdit.jl:1579
 in RunDebugREPL(::ASTInterpreter.Interpreter) at /home/tim/.julia/v0.5/ASTInterpreter/src/ASTInterpreter.jl:1715
 in (::Gallium.##106#108)(::#foo, ::UnitRange{Int64}) at ./<missing>:0
 in bar(::Int64, ::Int64) at ./REPL[2]:3
```
This crashes out of Gallium entirely, returning you to the regular julia prompt.

Unfortunately, this fix isn't enough on its own to make it work like you want, because now you get this error:
```jl
ERROR: UndefVarError: r not defined
 in _step_expr(::ASTInterpreter.Interpreter) at /home/tim/.julia/v0.5/ASTInterpreter/src/ASTInterpreter.jl:653
 in step_expr at /home/tim/.julia/v0.5/ASTInterpreter/src/ASTInterpreter.jl:666 [inlined]
 in #finish!#81(::Bool, ::Bool, ::Function, ::ASTInterpreter.Interpreter) at /home/tim/.julia/v0.5/ASTInterpreter/src/ASTInterpreter.jl:1743
 in eval_in_interp(::Gallium.JuliaStackFrame, ::Symbol, ::Symbol, ::String) at /home/tim/.julia/v0.5/ASTInterpreter/src/ASTInterpreter.jl:1299
 in eval_code(::ASTInterpreter.InterpreterState, ::String) at /home/tim/.julia/v0.5/ASTInterpreter/src/ASTInterpreter.jl:1552
 in (::ASTInterpreter.##72#78{ASTInterpreter.InterpreterState,Base.LineEdit.Prompt})(::Base.LineEdit.MIState, ::Base.AbstractIOBuffer{Array{UInt8,1}}, ::Bool) at /home/tim/.julia/v0.5/ASTInterpreter/src/ASTInterpreter.jl:1677
 in run_interface(::Base.Terminals.TTYTerminal, ::Base.LineEdit.ModalInterface) at ./LineEdit.jl:1579
 in RunDebugREPL(::ASTInterpreter.Interpreter) at /home/tim/.julia/v0.5/ASTInterpreter/src/ASTInterpreter.jl:1716
 in (::Gallium.##106#108)(::#foo, ::UnitRange{Int64}) at ./<missing>:0
 in bar(::Int64, ::Int64) at ./REPL[2]:3
```
However, at least this error doesn't abort debugging.
