### PR TITLE
IJulia support

### DIFF
--- a/src/ASTInterpreter.jl
+++ b/src/ASTInterpreter.jl
@@ -1697,11 +1697,15 @@ function RunDebugREPL(top_interp)
     Base.REPL.run_interface(repl.t, LineEdit.ModalInterface([panel,julia_prompt,search_prompt]))
 end
 
+# IJulia versions < 1.4.2 do not have `readprompt`
+ijulia_readline() = (isdefined(Main.IJulia, :readprompt) ?
+                     Main.IJulia.readprompt("debug> ") : readline(STDIN))
+
 function IJuliaRunDebugREPL(top_interp)
     state = InterpreterState(top_interp, top_interp, 1, nothing, nothing, nothing)
     print_status(state, state.interp)
 
-    while (line=readline(STDIN)) != "q"
+    while (line=ijulia_readline()) != "q"
         if startswith(line, "`")
             ok, result = eval_code(state, line[2:end])
             if ok


### PR DESCRIPTION
This PR provides a mode similar to IPython's `%debug`:

![screen shot 2017-01-21 at 14 21 52](https://cloud.githubusercontent.com/assets/8622776/22177060/04012c8a-dfe5-11e6-8aab-afe499fce4d8.png)

Both ASTInterpreter's and Gallium's master have precompilation issues for me on 0.5, so I haven't been able to test everything. `breakpoint_on_error()` freezes without any error message.

Would you like me to factor out some of the common code between `RunDebugREPL` and `IJuliaRunDebugREPL`? I looked into creating an `active_repl` object for IJulia so that we could use `RunDebugREPL`, but that seemed rather involved, and I didn't see any benefit. 

cc. @stevengj